### PR TITLE
Require buttonpress.sh is invoked as root, automatically detect user that called script and add flag to allow user to be set

### DIFF
--- a/buttonpress.sh
+++ b/buttonpress.sh
@@ -3,8 +3,37 @@
 # this is for running to put the keys into the mappings file
 # replace "USERNAME" in quotes with the username needing the login
 
-USERNAME="USERNAME"
+# Use logname as $USER or who will be root. 
+USERNAME="$(logname)"
+
+if [[ $(/usr/bin/id -u) -ne 0 ]]; then
+  echo "Please execute script as root"
+  exit 1
+fi
+
+while [ "$1" != "" ]; do
+  case $1 in 
+    --username)
+      shift
+      USERNAME=$1
+      ;;
+  esac
+  shift
+done
+
+if [ -z "$USERNAME" ]; then
+  echo "Username is not set, please use --username flag to set"
+fi
+
+read -p "u2f mapping will be generated for the user '$USERNAME'. Is this correct? (Y/N): "
+echo
+
+if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+  echo "Please call script again and user --username flag to specify username."
+  exit 1
+fi
 
 sudo -v
 echo "Enter PIN if required then Press the button"
-sudo sh -c "pamu2fcfg -u $USERNAME >> /etc/u2f_mappings"
+# Append new line
+pamu2fcfg -u $USERNAME >> /etc/u2f_mappings


### PR DESCRIPTION
Hey thanks for this repo, I want to try and use these scripts to set up Yubikey Passwordless on my side. But at the same time wanted to make it easier for me to execute if I need to repeat the process in the future.

This PR changes the buttonpress script a bit. 

- Adds requirement that script is executed as root.
- By default will generates mapping for the user that invoked the script
- Adds optional `--username` parameter that allows user to specify another user.