### PR TITLE
Prevent addition of Yubikey policy to services that do not exist or already have the policy included

### DIFF
--- a/update-mapping.sh
+++ b/update-mapping.sh
@@ -1,8 +1,27 @@
 #!/bin/bash
 
+# List of services to update policy for
+SERVICES=(
+  gdm-password
+  lightdm
+  sudo
+  login
+  polkit-1
+  xscreensaver
+)
+
 cd /etc/pam.d
 echo 'auth sufficient pam_u2f.so authfile=/etc/u2f_mappings cue' > common-u2f
-for f in gdm-password lightdm sudo login polkit-1 xscreensaver; do
-mv $f $f~
-awk '/@include common-auth/ {print "@include common-u2f"}; {print}' $f~ > $f
+for f in ${SERVICES[@]}; do
+  if [ ! -f $f ]; then
+    echo "[SKIP] $f does not exist"
+    continue
+  fi
+
+  if grep -Fxq "@include common-u2f" $f; then
+    echo "[SKIP] Updated policy exists in $f"
+  else
+    mv $f $f~
+    awk '/@include common-auth/ {print "@include common-u2f"}; {print}' $f~ > $f
+  fi
 done


### PR DESCRIPTION
Updates update-mapping.sh to do the following.

- Only update service configurations if the configuration files actually exist
- Only update service configurations if the configuration does not already include the common-u2f policy.